### PR TITLE
Gemspec in gemfile

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,5 +1,3 @@
 source 'https://rubygems.org'
 
-gem 'rspec'
-gem 'timecop'
-gem 'colorize'
+gemspec

--- a/Guardfile
+++ b/Guardfile
@@ -1,0 +1,4 @@
+guard 'rspec' do
+  watch(%r{^spec/.+_spec\.rb$})
+  watch(%r{^lib/(.+)\.rb$}) { |m| "spec/lib/#{m[1]}_spec.rb" }
+end

--- a/timert.gemspec
+++ b/timert.gemspec
@@ -16,6 +16,7 @@ Gem::Specification.new do |s|
     'http://github.com/mkwidzinska/timert'
 
   s.add_development_dependency 'rspec'
+  s.add_development_dependency 'guard-rspec'
   s.add_development_dependency 'timecop'
   s.add_runtime_dependency 'colorize'
 end


### PR DESCRIPTION
I think that:
- there is no need to provide a list of gems in `Gemfile` if you have `gemspec`.
- developing is much easier if you do not need to run `rspec` command after changes.
